### PR TITLE
fixed multi ACL inputs

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -50,15 +50,15 @@ if Rails.application.secrets.dig(:omniauth, :saml, :enabled)
     private
 
     def valid_user?(response)
-      valid_cn?(response.attributes[:ACL]) || valid_type?(response.attributes[:tipusUsuari])
+      valid_cn?(response.attributes.multi(:ACL)) || valid_type?(response.attributes.multi(:tipusUsuari))
     end
 
-    def valid_cn?(acl)
-      /cn=#{Chamber.env.saml.cn}(,|\b)/i.match? acl
+    def valid_cn?(acl_list)
+      acl_list.any? { |acl| /cn=#{Chamber.env.saml.cn}(,|\b)/i.match? acl }
     end
 
-    def valid_type?(type)
-      type&.in? Chamber.env.saml.user_types
+    def valid_type?(type_list)
+      type_list.any? { |type| type.in? Chamber.env.saml.user_types }
     end
   end
 


### PR DESCRIPTION
Patch that allows to check valid ACL into several inputs, like this:

`["cn=ACCESO,ou=Perfils,ou=PORTALINTRA,ou=App,o=imi", "cn=ACCES,ou=Perfils,ou=DecidimIntern,ou=App,o=imi"]`

This patch looks for any match in all the different inputs in the SAML response. If at least one of the inputs match the regex, the user is allowed to sign in

Same patch is added for user type validation, that will work if the user belongs to several groups.